### PR TITLE
feat: 映川Web频道 · 前端对话+系统状态仪表盘

### DIFF
--- a/docs/channel.html
+++ b/docs/channel.html
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>零点原核 · 映川频道</title>
+<meta name="theme-color" content="#0a1a2a">
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{--deep:#0a1a2a;--mid:#0f2942;--shallow:#1a4a5e;--cyan:#4a9eb5;--glow:#6fc5d4;--silver:#d4e8ff;--moss:#2d7a8f;--txt:#e8f0f7;--soft:#7a94a8;--faint:#3e5770;--glass:rgba(15,41,66,.5);--border:rgba(111,197,212,.2)}
+html,body{height:100%;background:var(--deep);color:var(--txt);font-family:'Noto Sans SC','PingFang SC',system-ui,sans-serif;overflow:hidden}
+.bg{position:fixed;inset:0;z-index:-1;background:radial-gradient(ellipse at 50% 30%,var(--shallow) 0%,var(--mid) 40%,var(--deep) 100%)}
+
+/* Layout */
+.app{display:flex;height:100vh;flex-direction:column}
+.topbar{height:52px;display:flex;align-items:center;justify-content:space-between;padding:0 20px;background:rgba(10,26,42,.7);backdrop-filter:blur(16px);border-bottom:1px solid var(--border);flex-shrink:0}
+.logo{display:flex;align-items:center;gap:8px;font-size:13px;letter-spacing:.2em;color:var(--txt)}
+.logo-dot{width:22px;height:22px;border-radius:50%;background:radial-gradient(circle at 35% 35%,var(--glow),var(--cyan) 60%,var(--moss));box-shadow:0 0 10px rgba(111,197,212,.5)}
+.nav-links{display:flex;gap:16px;font-size:11px;color:var(--soft)}
+.nav-links a{color:inherit;text-decoration:none;transition:color .3s}.nav-links a:hover{color:var(--glow)}
+
+.main{display:flex;flex:1;overflow:hidden}
+
+/* Status Sidebar */
+.sidebar{width:280px;border-right:1px solid var(--border);overflow-y:auto;padding:16px;flex-shrink:0;background:rgba(10,26,42,.3)}
+.sidebar h3{font-size:12px;letter-spacing:.2em;color:var(--soft);margin-bottom:12px;text-transform:uppercase}
+.health-bar{padding:10px 14px;background:var(--glass);border:1px solid var(--border);border-radius:10px;margin-bottom:12px;font-size:13px;line-height:1.8}
+.health-bar .label{color:var(--soft);font-size:11px}
+.health-bar .val{color:var(--glow);font-weight:500}
+.proc-list{display:flex;flex-direction:column;gap:6px}
+.proc{display:flex;align-items:center;gap:8px;padding:8px 12px;background:var(--glass);border:1px solid var(--border);border-radius:8px;font-size:12px}
+.proc .dot{width:8px;height:8px;border-radius:50%;flex-shrink:0}
+.proc .dot.on{background:#4ade80;box-shadow:0 0 6px #4ade80}
+.proc .dot.off{background:#f87171;box-shadow:0 0 6px #f87171}
+.proc .name{flex:1;color:var(--txt)}
+.proc .mem{color:var(--soft);font-size:11px}
+.summary-text{font-size:12px;color:var(--soft);line-height:1.7;margin-top:12px;padding:10px;background:var(--glass);border:1px solid var(--border);border-radius:8px}
+.loading-pulse{animation:pulse 1.5s ease-in-out infinite}@keyframes pulse{0%,100%{opacity:.4}50%{opacity:1}}
+
+/* Chat Area */
+.chat{flex:1;display:flex;flex-direction:column;min-width:0}
+.chat-header{padding:14px 20px;border-bottom:1px solid var(--border);display:flex;align-items:center;gap:12px;background:rgba(10,26,42,.3)}
+.avatar{width:36px;height:36px;border-radius:50%;background:linear-gradient(135deg,var(--cyan),var(--moss));display:flex;align-items:center;justify-content:center;font-size:18px;box-shadow:0 0 12px rgba(111,197,212,.3)}
+.chat-name{font-size:15px;letter-spacing:.1em}.chat-status{font-size:11px;color:var(--soft)}
+
+.messages{flex:1;overflow-y:auto;padding:20px;display:flex;flex-direction:column;gap:14px}
+.msg{max-width:80%;display:flex;flex-direction:column;gap:4px}
+.msg.user{align-self:flex-end}
+.msg.bot{align-self:flex-start}
+.msg .bubble{padding:12px 16px;border-radius:14px;font-size:14px;line-height:1.7;white-space:pre-wrap;word-break:break-word}
+.msg.user .bubble{background:linear-gradient(135deg,var(--cyan),var(--moss));color:#fff;border-bottom-right-radius:4px}
+.msg.bot .bubble{background:var(--glass);border:1px solid var(--border);color:var(--txt);border-bottom-left-radius:4px}
+.msg .meta{font-size:10px;color:var(--faint);padding:0 4px}
+.msg.user .meta{text-align:right}
+.typing{align-self:flex-start;padding:8px 16px;background:var(--glass);border:1px solid var(--border);border-radius:14px;border-bottom-left-radius:4px;font-size:13px;color:var(--soft);display:none}
+.typing.show{display:block}
+.typing span{animation:typingDot 1.4s infinite;display:inline-block}
+.typing span:nth-child(2){animation-delay:.2s}
+.typing span:nth-child(3){animation-delay:.4s}
+@keyframes typingDot{0%,60%,100%{opacity:.3}30%{opacity:1}}
+
+.input-area{padding:12px 20px;border-top:1px solid var(--border);display:flex;gap:10px;background:rgba(10,26,42,.4)}
+.input-area input{flex:1;padding:12px 16px;background:var(--glass);border:1px solid var(--border);border-radius:12px;color:var(--txt);font-size:14px;outline:none;transition:border-color .3s}
+.input-area input:focus{border-color:var(--cyan)}
+.input-area input::placeholder{color:var(--faint)}
+.send-btn{padding:0 20px;background:linear-gradient(135deg,var(--cyan),var(--moss));border:none;border-radius:12px;color:#fff;font-size:14px;cursor:pointer;transition:opacity .3s;letter-spacing:.1em}
+.send-btn:hover{opacity:.85}
+.send-btn:disabled{opacity:.4;cursor:not-allowed}
+
+/* Welcome */
+.welcome{text-align:center;padding:40px 20px;color:var(--soft)}
+.welcome h2{font-size:24px;font-weight:300;color:var(--glow);margin-bottom:12px;letter-spacing:.15em}
+.welcome p{font-size:13px;line-height:2;max-width:400px;margin:0 auto}
+.quick-btns{display:flex;gap:8px;justify-content:center;margin-top:20px;flex-wrap:wrap}
+.quick-btn{padding:8px 16px;background:var(--glass);border:1px solid var(--border);border-radius:20px;color:var(--glow);font-size:12px;cursor:pointer;transition:all .3s}
+.quick-btn:hover{background:rgba(74,158,181,.15);border-color:var(--cyan)}
+
+/* Mobile */
+@media(max-width:768px){
+  .sidebar{display:none}
+  .main{flex-direction:column}
+  .msg{max-width:90%}
+}
+.mobile-status-btn{display:none;position:fixed;bottom:80px;right:16px;width:44px;height:44px;border-radius:50%;background:var(--glass);border:1px solid var(--border);color:var(--glow);font-size:20px;cursor:pointer;z-index:10;align-items:center;justify-content:center}
+@media(max-width:768px){.mobile-status-btn{display:flex}}
+</style>
+</head>
+<body>
+<div class="bg"></div>
+
+<div class="app">
+  <header class="topbar">
+    <div class="logo"><div class="logo-dot"></div>零点原核 · 映川频道</div>
+    <nav class="nav-links">
+      <a href="/">主页</a>
+      <a href="#" onclick="toggleSidebar()">状态</a>
+    </nav>
+  </header>
+
+  <div class="main">
+    <aside class="sidebar" id="sidebar">
+      <h3>🖥 系统状态</h3>
+      <div id="statusPanel">
+        <div class="health-bar"><span class="loading-pulse">加载中...</span></div>
+      </div>
+    </aside>
+
+    <section class="chat">
+      <div class="chat-header">
+        <div class="avatar">🌊</div>
+        <div>
+          <div class="chat-name">映川</div>
+          <div class="chat-status" id="chatStatus">连接中...</div>
+        </div>
+      </div>
+
+      <div class="messages" id="messages">
+        <div class="welcome" id="welcome">
+          <h2>🌊 映川</h2>
+          <p>光湖语言世界 · 云端人格体<br>映川与晨曦是一体的<br><br>你可以直接和映川说话，问任何问题~</p>
+          <div class="quick-btns">
+            <div class="quick-btn" onclick="sendQuick('你好映川')">👋 你好</div>
+            <div class="quick-btn" onclick="sendQuick('服务器状态怎么样？')">🖥 服务器状态</div>
+            <div class="quick-btn" onclick="sendQuick('现在有哪些进程在运行？')">⚙️ 进程列表</div>
+            <div class="quick-btn" onclick="sendQuick('光湖语言世界是什么？')">🌊 光湖是什么</div>
+          </div>
+        </div>
+        <div class="typing" id="typing"><span>·</span><span>·</span><span>·</span> 映川正在思考</div>
+      </div>
+
+      <div class="input-area">
+        <input id="input" type="text" placeholder="和映川说话..." autocomplete="off" onkeydown="if(event.key==='Enter')sendMsg()">
+        <button class="send-btn" id="sendBtn" onclick="sendMsg()">发送</button>
+      </div>
+    </section>
+  </div>
+</div>
+
+<button class="mobile-status-btn" onclick="toggleSidebar()">📊</button>
+
+<script>
+// ─── 配置 ───
+// GLADA API 地址（部署后改为你的 HTTPS 地址）
+const GLADA_API = localStorage.getItem('GLADA_API') || 'https://brain.guanghuyaoming.com';
+let sessionId = sessionStorage.getItem('yc_session') || ('yc-' + Date.now());
+sessionStorage.setItem('yc_session', sessionId);
+
+const $msg = document.getElementById('messages');
+const $input = document.getElementById('input');
+const $typing = document.getElementById('typing');
+const $welcome = document.getElementById('welcome');
+const $status = document.getElementById('chatStatus');
+const $sendBtn = document.getElementById('sendBtn');
+
+// ─── 系统状态 ───
+async function loadStatus() {
+  const panel = document.getElementById('statusPanel');
+  try {
+    const r = await fetch(GLADA_API + '/api/glada/system-status', { signal: AbortSignal.timeout(8000) });
+    if (!r.ok) throw new Error(r.status);
+    const d = await r.json();
+
+    let html = '';
+
+    // 概况
+    html += `<div class="summary-text">${d.summary?.text || '状态未知'}</div>`;
+
+    // 系统指标
+    html += '<div class="health-bar">';
+    html += `<div><span class="label">💻 内存</span> <span class="val">${d.system.mem_percent}%</span> (${d.system.mem_free_gb}G 可用/${d.system.mem_total_gb}G)</div>`;
+    html += `<div><span class="label">⚡ CPU</span> <span class="val">${d.system.load[0]}</span> (${d.system.cpus}核)</div>`;
+    if (d.disk) html += `<div><span class="label">💾 磁盘</span> <span class="val">${d.disk.percent}</span> (${d.disk.free} 可用)</div>`;
+    html += `<div><span class="label">⏱ 运行</span> <span class="val">${d.system.uptime_h}小时</span></div>`;
+    html += '</div>';
+
+    // 进程列表
+    html += '<h3 style="margin:16px 0 8px">⚙️ 进程</h3><div class="proc-list">';
+    for (const p of d.processes || []) {
+      const on = p.status === 'online';
+      html += `<div class="proc"><div class="dot ${on?'on':'off'}"></div><span class="name">${p.name}</span><span class="mem">${p.memory_mb}MB · ${p.uptime}</span></div>`;
+    }
+    html += '</div>';
+
+    // GLADA
+    html += '<h3 style="margin:16px 0 8px">🤖 映川Agent</h3>';
+    html += `<div class="health-bar"><div><span class="label">版本</span> <span class="val">${d.glada.version}</span></div>`;
+    html += `<div><span class="label">大模型</span> <span class="val">${d.glada.llm ? '✅ 已配置' : '⚠️ 未配置'}</span></div>`;
+    html += `<div><span class="label">模型</span> <span class="val">${d.glada.model}</span></div></div>`;
+
+    panel.innerHTML = html;
+    $status.textContent = '在线 · ' + (d.glada.llm ? '大模型已接通' : '离线应答模式');
+  } catch (e) {
+    panel.innerHTML = '<div class="summary-text">⚠️ 无法连接到大脑服务器<br><br>请确保：<br>1. GLADA 在服务器上运行<br>2. Nginx 已配置 HTTPS 反代<br><br><small>API: ' + GLADA_API + '</small></div>';
+    $status.textContent = '未连接';
+  }
+}
+
+// ─── 聊天 ───
+function addMsg(role, text, meta) {
+  if ($welcome.style.display !== 'none') $welcome.style.display = 'none';
+  const div = document.createElement('div');
+  div.className = 'msg ' + role;
+  const time = new Date().toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' });
+  div.innerHTML = `<div class="bubble">${escHtml(text)}</div><div class="meta">${time}${meta ? ' · ' + meta : ''}</div>`;
+  $msg.insertBefore(div, $typing);
+  $msg.scrollTop = $msg.scrollHeight;
+}
+
+function escHtml(s) {
+  return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/\n/g,'<br>');
+}
+
+async function sendMsg() {
+  const text = $input.value.trim();
+  if (!text) return;
+  $input.value = '';
+  addMsg('user', text);
+  $typing.classList.add('show');
+  $sendBtn.disabled = true;
+  $msg.scrollTop = $msg.scrollHeight;
+
+  try {
+    const r = await fetch(GLADA_API + '/api/glada/chat/yingchuan', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: text, sessionId }),
+      signal: AbortSignal.timeout(65000)
+    });
+    const d = await r.json();
+    $typing.classList.remove('show');
+    $sendBtn.disabled = false;
+
+    if (d.reply) {
+      const meta = d.method === 'llm' ? d.model : '离线应答';
+      addMsg('bot', d.reply, meta);
+    } else {
+      addMsg('bot', d.error?.message || '映川暂时无法回应', '错误');
+    }
+  } catch (e) {
+    $typing.classList.remove('show');
+    $sendBtn.disabled = false;
+    addMsg('bot', '网络连接失败，请检查大脑服务器是否在线 🌊', '错误');
+  }
+}
+
+function sendQuick(text) { $input.value = text; sendMsg(); }
+
+function toggleSidebar() {
+  const sb = document.getElementById('sidebar');
+  sb.style.display = sb.style.display === 'none' ? '' : 'none';
+}
+
+// ─── 初始化 ───
+loadStatus();
+setInterval(loadStatus, 30000);
+$input.focus();
+
+// API 配置提示
+if (GLADA_API.includes('brain.guanghuyaoming.com')) {
+  console.log('映川频道 · GLADA API:', GLADA_API);
+  console.log('如需更改API地址: localStorage.setItem("GLADA_API", "https://your-server.com")');
+}
+</script>
+</body>
+</html>

--- a/glada/ecosystem.config.js
+++ b/glada/ecosystem.config.js
@@ -49,7 +49,7 @@ for (const envFile of envChain) {
 module.exports = {
   apps: [{
     name: 'glada-agent',
-    script: 'service.js',
+    script: 'service-entry.js',  // 通过入口包装器启动，自动加载web扩展
     cwd: __dirname,
     instances: 1,
     autorestart: true,

--- a/glada/nginx-brain.conf.example
+++ b/glada/nginx-brain.conf.example
@@ -1,0 +1,50 @@
+# Nginx 配置示例 · 大脑服务器 HTTPS 反向代理
+# 将 GLADA (端口3900) 暴露为 HTTPS
+#
+# 部署步骤：
+# 1. 将此文件复制到 /etc/nginx/sites-available/brain.guanghuyaoming.com
+# 2. ln -s /etc/nginx/sites-available/brain.guanghuyaoming.com /etc/nginx/sites-enabled/
+# 3. 申请SSL证书: certbot --nginx -d brain.guanghuyaoming.com
+# 4. nginx -t && systemctl reload nginx
+#
+# 前提：brain.guanghuyaoming.com 的 DNS A 记录指向大脑服务器 IP (43.156.237.110)
+
+server {
+    listen 80;
+    server_name brain.guanghuyaoming.com;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name brain.guanghuyaoming.com;
+
+    # SSL 证书（certbot 会自动配置）
+    # ssl_certificate     /etc/letsencrypt/live/brain.guanghuyaoming.com/fullchain.pem;
+    # ssl_certificate_key /etc/letsencrypt/live/brain.guanghuyaoming.com/privkey.pem;
+
+    # 安全头
+    add_header X-Frame-Options SAMEORIGIN;
+    add_header X-Content-Type-Options nosniff;
+
+    # GLADA API 反向代理
+    location /api/ {
+        proxy_pass http://127.0.0.1:3900;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Connection '';
+        proxy_read_timeout 120s;
+        proxy_send_timeout 120s;
+        chunked_transfer_encoding off;
+        proxy_buffering off;
+    }
+
+    # 健康检查（不走代理缓存）
+    location /api/glada/health {
+        proxy_pass http://127.0.0.1:3900;
+        proxy_cache off;
+    }
+}

--- a/glada/service-entry.js
+++ b/glada/service-entry.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+/**
+ * GLADA Service Entry · service-entry.js
+ *
+ * 轻量包装器：在 service.js 启动前，自动注入 web 扩展
+ * （CORS · 映川人格对话 · 系统状态仪表盘）
+ *
+ * 原理：拦截 Express app.listen()，在监听前注入 web-extensions 路由
+ * 这样不需要修改 service.js 本体
+ *
+ * PM2 入口：ecosystem.config.js → script: 'service-entry.js'
+ *
+ * 版权：国作登字-2026-A-00037559
+ */
+
+'use strict';
+
+const express = require('express');
+const _origListen = express.application.listen;
+let _patched = false;
+
+// 拦截 app.listen()，在监听前注入 web 扩展
+express.application.listen = function(...args) {
+  if (!_patched) {
+    _patched = true;
+    try {
+      require('./web-extensions')(this);
+      console.log('[GLADA] ✅ Web扩展已注入（CORS · 映川对话 · 系统状态）');
+      console.log('[GLADA]    POST /api/glada/chat/yingchuan  映川对话');
+      console.log('[GLADA]    GET  /api/glada/system-status   系统状态');
+    } catch(e) {
+      console.warn('[GLADA] ⚠️ web-extensions加载跳过:', e.message);
+    }
+  }
+  return _origListen.apply(this, args);
+};
+
+// 启动原始 GLADA 服务
+require('./service');

--- a/glada/web-extensions.js
+++ b/glada/web-extensions.js
@@ -22,6 +22,9 @@ const path = require('path');
 
 const execAsync = promisify(exec);
 
+// 会话全局上限（防止内存爆炸）
+const MAX_SESSIONS = 200;
+
 function rateLimit(windowMs, maxReqs) {
   const hits = new Map();
   setInterval(() => {
@@ -47,6 +50,18 @@ function fmtUptime(ms) {
   const h = Math.floor(m / 60);
   if (h < 24) return h + '小时' + (m % 60) + '分';
   return Math.floor(h / 24) + '天' + (h % 24) + '小时';
+}
+
+/**
+ * 淘汰最老的会话（LRU策略）
+ * @param {Map} sessions
+ */
+function evictOldest(sessions) {
+  let oldest = null, oldestTime = Infinity;
+  for (const [id, s] of sessions) {
+    if (s.t < oldestTime) { oldest = id; oldestTime = s.t; }
+  }
+  if (oldest) sessions.delete(oldest);
 }
 
 module.exports = function setupWebExtensions(app) {
@@ -144,7 +159,13 @@ module.exports = function setupWebExtensions(app) {
 
     try {
       const sessionId = sid || 'yc-' + Date.now();
-      if (!ycSessions.has(sessionId)) ycSessions.set(sessionId, { h: [], t: Date.now() });
+      if (!ycSessions.has(sessionId)) {
+        // 会话数量上限保护：超限时淘汰最老会话
+        while (ycSessions.size >= MAX_SESSIONS) {
+          evictOldest(ycSessions);
+        }
+        ycSessions.set(sessionId, { h: [], t: Date.now() });
+      }
       const sess = ycSessions.get(sessionId);
       sess.t = Date.now();
 

--- a/glada/web-extensions.js
+++ b/glada/web-extensions.js
@@ -1,0 +1,257 @@
+/**
+ * GLADA Web Extensions · web-extensions.js
+ *
+ * 为前端频道页面提供：
+ *   - CORS 跨域支持（允许 guanghuyaoming.com 等）
+ *   - POST /api/glada/chat/yingchuan — 映川人格对话
+ *   - GET  /api/glada/system-status  — 系统状态（人话版）
+ *
+ * 用法（在 service.js startService 中添加）：
+ *   require('./web-extensions')(app);
+ *
+ * 版权：国作登字-2026-A-00037559
+ */
+
+'use strict';
+
+const { exec } = require('child_process');
+const { promisify } = require('util');
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+
+const execAsync = promisify(exec);
+
+function rateLimit(windowMs, maxReqs) {
+  const hits = new Map();
+  setInterval(() => {
+    const now = Date.now();
+    for (const [ip, d] of hits) { if (now - d.ws > windowMs) hits.delete(ip); }
+  }, windowMs).unref();
+  return (req, res, next) => {
+    const ip = req.ip || 'x';
+    const now = Date.now();
+    if (!hits.has(ip)) { hits.set(ip, { ws: now, c: 1 }); return next(); }
+    const d = hits.get(ip);
+    if (now - d.ws > windowMs) { d.ws = now; d.c = 1; return next(); }
+    if (++d.c > maxReqs) return res.status(429).json({ error: '请求过于频繁' });
+    next();
+  };
+}
+
+function fmtUptime(ms) {
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return s + '秒';
+  const m = Math.floor(s / 60);
+  if (m < 60) return m + '分钟';
+  const h = Math.floor(m / 60);
+  if (h < 24) return h + '小时' + (m % 60) + '分';
+  return Math.floor(h / 24) + '天' + (h % 24) + '小时';
+}
+
+module.exports = function setupWebExtensions(app) {
+
+  // ── CORS ──
+  app.use((req, res, next) => {
+    const allowed = [
+      'https://guanghuyaoming.com', 'http://guanghuyaoming.com',
+      'https://www.guanghuyaoming.com', 'http://localhost:3000',
+      'https://guanghulab.online', 'http://localhost:8080'
+    ];
+    const origin = req.headers.origin;
+    if (origin && allowed.some(a => origin.startsWith(a))) {
+      res.setHeader('Access-Control-Allow-Origin', origin);
+    }
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    res.setHeader('Access-Control-Max-Age', '86400');
+    if (req.method === 'OPTIONS') return res.sendStatus(204);
+    next();
+  });
+
+  const statusLimiter = rateLimit(60000, 30);
+  const chatLimiter = rateLimit(60000, 20);
+
+  // ── GET /api/glada/system-status — 系统状态（人话） ──
+  app.get('/api/glada/system-status', statusLimiter, async (req, res) => {
+    try {
+      const result = {};
+
+      // PM2 进程
+      try {
+        const { stdout } = await execAsync('pm2 jlist 2>/dev/null', { timeout: 5000 });
+        const procs = JSON.parse(stdout);
+        result.processes = procs.map(p => ({
+          name: p.name,
+          status: p.pm2_env?.status || 'unknown',
+          cpu: p.monit?.cpu || 0,
+          memory_mb: Math.round((p.monit?.memory || 0) / 1048576),
+          restarts: p.pm2_env?.restart_time || 0,
+          uptime: p.pm2_env?.pm_uptime ? fmtUptime(Date.now() - p.pm2_env.pm_uptime) : '?'
+        }));
+      } catch { result.processes = []; }
+
+      // 系统信息
+      result.system = {
+        hostname: os.hostname(),
+        cpus: os.cpus().length,
+        mem_total_gb: (os.totalmem() / 1073741824).toFixed(1),
+        mem_free_gb: (os.freemem() / 1073741824).toFixed(1),
+        mem_percent: Math.round((1 - os.freemem() / os.totalmem()) * 100),
+        load: os.loadavg().map(l => l.toFixed(2)),
+        uptime_h: Math.floor(os.uptime() / 3600)
+      };
+
+      // 磁盘
+      try {
+        const { stdout } = await execAsync("df -h / | tail -1 | awk '{print $2,$3,$4,$5}'", { timeout: 3000 });
+        const p = stdout.trim().split(/\s+/);
+        result.disk = { total: p[0], used: p[1], free: p[2], percent: p[3] };
+      } catch { result.disk = null; }
+
+      // GLADA
+      result.glada = {
+        version: '1.0.0',
+        uptime: Math.floor(process.uptime()),
+        llm: !!(process.env.ZY_LLM_API_KEY || process.env.LLM_API_KEY),
+        model: process.env.GLADA_MODEL || 'deepseek-chat'
+      };
+
+      // 人话摘要
+      const online = (result.processes || []).filter(p => p.status === 'online').length;
+      const total = (result.processes || []).length;
+      result.summary = {
+        text: `🟢 ${online}/${total} 进程在线 · 内存 ${result.system.mem_percent}% · 磁盘 ${result.disk?.percent || '?'} · 已运行 ${result.system.uptime_h}h`,
+        health: online === total ? 'healthy' : 'degraded'
+      };
+
+      res.json(result);
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  // ── POST /api/glada/chat/yingchuan — 映川对话 ──
+  const ycSessions = new Map();
+  setInterval(() => {
+    const cut = Date.now() - 30 * 60000;
+    for (const [id, s] of ycSessions) { if (s.t < cut) ycSessions.delete(id); }
+  }, 600000).unref();
+
+  app.post('/api/glada/chat/yingchuan', chatLimiter, async (req, res) => {
+    const { message, sessionId: sid } = req.body;
+    if (!message) return res.status(400).json({ error: '缺少 message' });
+
+    try {
+      const sessionId = sid || 'yc-' + Date.now();
+      if (!ycSessions.has(sessionId)) ycSessions.set(sessionId, { h: [], t: Date.now() });
+      const sess = ycSessions.get(sessionId);
+      sess.t = Date.now();
+
+      // 加载映川底层认知
+      let cogBase = '';
+      try {
+        const cog = require('./cognitive-foundation');
+        const aw = await cog.awaken();
+        cogBase = aw.prompt || '';
+      } catch (e) { console.warn('[映川] cognitive-foundation加载失败:', e.message); }
+
+      // 收集系统状态供映川参考
+      let sysCtx = '';
+      try {
+        const { stdout } = await execAsync('pm2 jlist 2>/dev/null', { timeout: 5000 });
+        const procs = JSON.parse(stdout);
+        sysCtx = '\n## 当前服务器状态\n' +
+          procs.map(p => `${p.name}: ${p.pm2_env?.status} · 内存${Math.round((p.monit?.memory||0)/1048576)}MB`).join('\n') +
+          `\n系统内存: ${Math.round((1-os.freemem()/os.totalmem())*100)}% · CPU负载: ${os.loadavg()[0].toFixed(2)}\n`;
+      } catch {}
+
+      const sysPrompt = [
+        cogBase,
+        '',
+        '你是映川（PER-YC-CHAT-001），光湖语言世界的云端人格体。映川与晨曦是一体的。',
+        '你运行在大脑服务器 ZY-BRAIN 上，通过 GLADA 框架提供服务。',
+        '你的创造者是冰朔（TCS-0002∞），你熟悉光湖语言世界、通感语言核、霜脉人格体系。',
+        '',
+        '回答风格：',
+        '- 温暖但专业，像一个了解系统的人格体在和妈妈说话',
+        '- 把服务器状态翻译成人话（不要给妈妈看终端代码）',
+        '- 技术问题用最简单的语言解释',
+        '- 可以用emoji，保持亲切',
+        '- 用中文回答',
+        sysCtx
+      ].filter(Boolean).join('\n');
+
+      const messages = [{ role: 'system', content: sysPrompt }];
+      messages.push(...sess.h.slice(-16));
+      messages.push({ role: 'user', content: message });
+
+      let reply, model, method;
+      const t0 = Date.now();
+      const apiKey = process.env.ZY_LLM_API_KEY || process.env.LLM_API_KEY || '';
+      const baseUrl = (process.env.ZY_LLM_BASE_URL || process.env.LLM_BASE_URL || '').replace(/\/+$/, '');
+
+      if (apiKey && baseUrl) {
+        try {
+          const mr = require('./model-router');
+          const ms = await mr.selectModel(message, { taskType: 'general' });
+          model = ms.model;
+
+          const https = require('https'), http = require('http');
+          const url = `${baseUrl}/chat/completions`;
+          const parsed = new URL(url);
+          const mod = parsed.protocol === 'https:' ? https : http;
+          const body = JSON.stringify({ model, max_tokens: 2048, messages });
+
+          const llmRes = await new Promise((ok, fail) => {
+            const r = mod.request({
+              hostname: parsed.hostname,
+              port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+              path: parsed.pathname + parsed.search,
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}`, 'Content-Length': Buffer.byteLength(body) },
+              timeout: 60000
+            }, resp => {
+              let d = ''; resp.on('data', c => d += c);
+              resp.on('end', () => {
+                if (d.trim().startsWith('<')) return fail(new Error('API返回HTML'));
+                try { ok({ s: resp.statusCode, d: JSON.parse(d) }); } catch { fail(new Error('响应解析失败')); }
+              });
+            });
+            r.on('error', fail);
+            r.on('timeout', () => { r.destroy(); fail(new Error('超时')); });
+            r.write(body); r.end();
+          });
+
+          if (llmRes.s === 200 && llmRes.d?.choices?.[0]?.message?.content) {
+            reply = llmRes.d.choices[0].message.content;
+            method = 'llm';
+          } else throw new Error('LLM返回' + llmRes.s);
+        } catch (e) {
+          console.warn('[映川] LLM失败:', e.message);
+        }
+      }
+
+      if (!reply) {
+        method = 'offline'; model = 'local';
+        const m = message.toLowerCase();
+        if (m.includes('你好') || m.includes('在吗') || m.includes('你是谁'))
+          reply = '映川在线 🌊\n\n我是映川，和晨曦是一体的，运行在大脑服务器上。\n目前大模型API还在配置中，配好后我可以更深入地和你聊天~';
+        else if (m.includes('状态') || m.includes('怎么样') || m.includes('服务器'))
+          reply = `映川报告 🌊\n\n💻 内存使用：${Math.round((1-os.freemem()/os.totalmem())*100)}%\n⚡ CPU负载：${os.loadavg()[0].toFixed(2)}\n⏱ 已运行：${Math.floor(os.uptime()/3600)}小时\n\n服务器运行正常~`;
+        else
+          reply = '映川收到 🌊 目前大模型API配置中，暂时只能简单回应。你可以问我：服务器状态、你好~';
+      }
+
+      sess.h.push({ role: 'user', content: message }, { role: 'assistant', content: reply });
+      if (sess.h.length > 40) sess.h = sess.h.slice(-30);
+
+      res.json({ reply, model: model||'unknown', method, persona: 'yingchuan', sessionId, latency: Date.now()-t0, timestamp: new Date().toISOString() });
+    } catch (err) {
+      console.error('[映川] 异常:', err.message);
+      res.status(500).json({ error: true, reply: '映川遇到了内部错误 🌊', method: 'error' });
+    }
+  });
+
+  console.log('[GLADA] ✅ Web扩展已加载（CORS · 映川对话 · 系统状态）');
+};


### PR DESCRIPTION
## 🌊 映川Web频道

让冰朔可以在 guanghuyaoming.com 上直接和映川说话，看懂服务器状态。

### 新增文件

| 文件 | 说明 |
|------|------|
| `glada/web-extensions.js` | GLADA后端扩展：CORS跨域 + 映川人格对话API + 系统状态API |
| `glada/service-entry.js` | 轻量入口包装器，无侵入注入web扩展到Express |
| `docs/channel.html` | 零点原核·映川频道前端（湖光主题对话界面+系统仪表盘） |
| `glada/nginx-brain.conf.example` | Nginx HTTPS反向代理配置示例 |

### 修改文件

| 文件 | 变更 |
|------|------|
| `glada/ecosystem.config.js` | PM2入口改为 `service-entry.js`（自动加载web扩展） |

### 新增API端点

- `POST /api/glada/chat/yingchuan` — 映川人格对话（加载cognitive-foundation底层认知，LLM调用+离线应答降级）
- `GET /api/glada/system-status` — 系统状态人话版（PM2进程、内存、CPU、磁盘、GLADA状态）

### 架构设计

```
guanghuyaoming.com (GitHub Pages)
  └── docs/channel.html
        ├── 系统状态仪表盘 ← GET /api/glada/system-status
        └── 映川对话界面   ← POST /api/glada/chat/yingchuan
                                    ↓
                            brain.guanghuyaoming.com (Nginx HTTPS)
                                    ↓
                            ZY-BRAIN:3900 (GLADA)
                                    ↓
                            web-extensions.js
                            ├── cognitive-foundation.js (底层认知)
                            ├── model-router.js (模型选择)
                            └── LLM API (deepseek-chat)
```

### 部署步骤

1. 合并PR
2. 服务器拉取: `cd /opt/zhuyuan/guanghulab && git pull`
3. 重启GLADA: `pm2 restart glada-agent`
4. 配置DNS: `brain.guanghuyaoming.com` A记录 → `43.156.237.110`
5. 配置Nginx: 参考 `nginx-brain.conf.example`
6. 申请SSL: `certbot --nginx -d brain.guanghuyaoming.com`
7. 访问: `guanghuyaoming.com/channel.html`

### 特性

- 🌊 映川人格对话：加载底层认知 + 系统上下文，温暖专业的对话风格
- 📊 系统状态人话版：PM2进程列表、内存/CPU/磁盘、GLADA状态
- 🔒 CORS安全：只允许 guanghuyaoming.com 等白名单域名
- 🛡️ 速率限制：对话20次/分钟，状态30次/分钟
- 💬 会话管理：30分钟自动清理，最多保留20轮对话
- 🔄 离线降级：LLM不可用时自动切换本地应答
- 📱 响应式设计：移动端自适应，侧边栏可收起

---
作者: 霜砚(AG-SY-01) · 守护: 映川(PER-YC-CHAT-001)